### PR TITLE
Fixing getOptimalLoot algorithm edge cases

### DIFF
--- a/Optimal-Cayo-Perico-Take/Constants.swift
+++ b/Optimal-Cayo-Perico-Take/Constants.swift
@@ -15,7 +15,7 @@ public enum SecondaryLootTypes: String, CaseIterable {
     case Weed
     case Cash
     
-    func getLootParams() -> ((Double, Double), Double) {
+    private func getLootParams() -> ((Double, Double), Double) {
         switch self {
         case .Gold:
             return ((328584, 333192), 2 / 3)
@@ -28,6 +28,18 @@ public enum SecondaryLootTypes: String, CaseIterable {
         case .Cash:
             return ((78480, 89420), 0.25)
         }
+    }
+    
+    func getMinValue() -> Double {
+        self.getLootParams().0.0
+    }
+    
+    func getMaxValue() -> Double {
+        self.getLootParams().0.1
+    }
+    
+    func getWeight() -> Double {
+        self.getLootParams().1
     }
 }
 

--- a/Optimal-Cayo-Perico-Take/OptimalLootUtils.swift
+++ b/Optimal-Cayo-Perico-Take/OptimalLootUtils.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class OptimalLootUtils {
-    static func fractionalKnapsack(capacity: Double, weights: [Double], values: [Double], lootItems: [SecondaryLootTypes]) -> [Double] {
+    static func fractionalKnapsack(capacity: Double, weights: [Double], values: [Double]) -> [Double] {
         let idxs = weights.indices
         var ratioTuples = idxs.map { ($0, values[$0] / weights[$0]) }
         ratioTuples.sort {lhs, rhs in lhs.1 > rhs.1} // sort in decreasing order
@@ -23,11 +23,9 @@ class OptimalLootUtils {
             if currCapacity - weights[idx] >= 0 {
                 currCapacity -= weights[idx]
                 itemsUsed[idx] = 1
-            } else if lootItems[idx] != .Art {
+            } else {
                 itemsUsed[idx] = currCapacity / weights[idx]
                 currCapacity = 0
-            } else {
-                itemsUsed[idx] = 0
             }
         }
         
@@ -38,8 +36,8 @@ class OptimalLootUtils {
         var valuesObtained: [SecondaryLootTypes: (Double, Double)] = [:]
         
         for lootType in lootGrabbed.keys {
-            let lowerBound = lootType.getLootParams().0.0
-            let upperBound = lootType.getLootParams().0.1
+            let lowerBound = lootType.getMinValue()
+            let upperBound = lootType.getMaxValue()
             valuesObtained[lootType] = (lootGrabbed[lootType]! * lowerBound, lootGrabbed[lootType]! * upperBound)
         }
         
@@ -48,8 +46,8 @@ class OptimalLootUtils {
     
     static func getTotalValues(lootGrabbed: [SecondaryLootTypes: Double]) -> (Double, Double) {
         return lootGrabbed.keys.reduce((0.0, 0.0)) { totals, lootType in
-            let lowerBound = lootType.getLootParams().0.0
-            let upperBound = lootType.getLootParams().0.1
+            let lowerBound = lootType.getMinValue()
+            let upperBound = lootType.getMaxValue()
             return (totals.0 + lootGrabbed[lootType]! * lowerBound, totals.1 + lootGrabbed[lootType]! * upperBound)
         }
     }
@@ -58,24 +56,24 @@ class OptimalLootUtils {
         var weightsObtained: [SecondaryLootTypes: Double] = [:]
         
         for lootType in lootGrabbed.keys {
-            weightsObtained[lootType] = lootGrabbed[lootType]! * lootType.getLootParams().1
+            weightsObtained[lootType] = lootGrabbed[lootType]! * lootType.getWeight()
         }
         
         return weightsObtained
     }
     
     static func getTotalWeight(lootGrabbed: [SecondaryLootTypes: Double]) -> Double {
-        return lootGrabbed.keys.reduce(0.0) { total, lootType in total + lootGrabbed[lootType]! * lootType.getLootParams().1 }
+        return lootGrabbed.keys.reduce(0.0) { total, lootType in total + lootGrabbed[lootType]! * lootType.getWeight() }
     }
     
-    static func getOptimalLoot(capacity: Double, lootCounts: [SecondaryLootTypes: Double]) -> [SecondaryLootTypes: Double] {
+    private static func getOptimalLootHelper(capacity: Double, lootCounts: [SecondaryLootTypes: Double]) -> [SecondaryLootTypes: Double] {
         let missingLootTypes = SecondaryLootTypes.allCases.filter { lootType in lootCounts[lootType] == 0 }
         let presentLootTypes = SecondaryLootTypes.allCases.filter { lootType in lootCounts[lootType] != 0 }
         
-        let weights = presentLootTypes.map { lootType in lootType.getLootParams().1 * (lootCounts[lootType]!) }
-        let values = presentLootTypes.map { lootType in lootType.getLootParams().0.1 * (lootCounts[lootType]!) }
+        let weights = presentLootTypes.map { lootType in lootType.getWeight() * (lootCounts[lootType]!) }
+        let values = presentLootTypes.map { lootType in lootType.getMaxValue() * (lootCounts[lootType]!) }
         
-        let itemsUsed = fractionalKnapsack(capacity: capacity, weights: weights, values: values, lootItems: presentLootTypes)
+        let itemsUsed = fractionalKnapsack(capacity: capacity, weights: weights, values: values)
         
         var optimalLoot: [SecondaryLootTypes: Double] = [:]
         for (idx, lootType) in presentLootTypes.enumerated() {
@@ -85,6 +83,35 @@ class OptimalLootUtils {
         for lootType in missingLootTypes {
             optimalLoot[lootType] = 0
         }
+        
+        return optimalLoot
+    }
+    
+    static func getOptimalLoot(capacity: Double, lootCounts: [SecondaryLootTypes: Double]) -> [SecondaryLootTypes: Double] {
+        let maxNumArtItems = Int(lootCounts[.Art]!)
+        let artWeight = SecondaryLootTypes.Art.getWeight()
+        let artValues = (SecondaryLootTypes.Art.getMinValue(), SecondaryLootTypes.Art.getMaxValue())
+        var choices: [(Double, Double)] = []
+        var lootCountsCopy = lootCounts
+        lootCountsCopy[.Art] = 0
+        
+        for numArtItems in 0 ... maxNumArtItems {
+            let numArtItemsDbl = Double(numArtItems)
+            let alteredCapacity = capacity - artWeight * numArtItemsDbl
+            let optimalLoot = getOptimalLootHelper(capacity: alteredCapacity, lootCounts: lootCountsCopy)
+            var totalValues = getTotalValues(lootGrabbed: optimalLoot)
+            totalValues = (totalValues.0 + artValues.0 * numArtItemsDbl, totalValues.1 + artValues.1 * numArtItemsDbl)
+            
+            choices.append(totalValues)
+        }
+        
+        let indices = choices.indices
+        let numArtItems = indices.max { choices[$0].1 < choices[$1].1 }
+        let numArtItemsDbl = Double(numArtItems!)
+        
+        let alteredCapacity = capacity - artWeight * numArtItemsDbl
+        var optimalLoot = getOptimalLootHelper(capacity: alteredCapacity, lootCounts: lootCountsCopy)
+        optimalLoot[.Art] = numArtItemsDbl
         
         return optimalLoot
     }

--- a/Optimal-Cayo-Perico-TakeTests/Optimal_Cayo_Perico_TakeTests.swift
+++ b/Optimal-Cayo-Perico-TakeTests/Optimal_Cayo_Perico_TakeTests.swift
@@ -44,13 +44,35 @@ class Optimal_Cayo_Perico_TakeTests: XCTestCase {
         let optimalLoot = OptimalLootUtils.getOptimalLoot(capacity: capacity, lootCounts: lootCounts)
         let valuesObtained = OptimalLootUtils.getValuesObtained(lootGrabbed: optimalLoot)
         let totalValuesObtained = OptimalLootUtils.getTotalValues(lootGrabbed: optimalLoot)
-        let actualTotalValues = (3 * SecondaryLootTypes.Gold.getLootParams().0.0, 3 * SecondaryLootTypes.Gold.getLootParams().0.1)
+        let actualTotalValues = (3 * SecondaryLootTypes.Gold.getMinValue(), 3 * SecondaryLootTypes.Gold.getMaxValue())
         
         XCTAssertEqual(optimalLoot[SecondaryLootTypes.Gold]!, 3)
         XCTAssertEqual(valuesObtained[SecondaryLootTypes.Gold]!.0, actualTotalValues.0)
         XCTAssertEqual(valuesObtained[SecondaryLootTypes.Gold]!.1, actualTotalValues.1)
         XCTAssertEqual(totalValuesObtained.0, actualTotalValues.0)
         XCTAssertEqual(totalValuesObtained.1, actualTotalValues.1)
+    }
+    
+    func testOptimalLootGoldArt() {
+        let capacity: Double = 1
+        let lootCounts: [SecondaryLootTypes: Double] = [
+            SecondaryLootTypes.Gold: 1,
+            SecondaryLootTypes.Art: 1,
+            SecondaryLootTypes.Cash: 0,
+            SecondaryLootTypes.Coke: 0,
+            SecondaryLootTypes.Weed: 0
+        ]
+        
+        let optimalLoot = OptimalLootUtils.getOptimalLoot(capacity: capacity, lootCounts: lootCounts)
+        for lootType in SecondaryLootTypes.allCases {
+            if lootType == .Gold {
+                XCTAssertEqual(optimalLoot[lootType]!, 0.75, accuracy: ACCURACY)
+            } else if lootType == .Art {
+                XCTAssertEqual(optimalLoot[lootType]!, 1, accuracy: ACCURACY)
+            } else {
+                XCTAssertEqual(optimalLoot[lootType]!, 0, accuracy: ACCURACY)
+            }
+        }
     }
     
     func testOptimalLootGold() {
@@ -144,6 +166,24 @@ class Optimal_Cayo_Perico_TakeTests: XCTestCase {
         for lootType in SecondaryLootTypes.allCases {
             if lootType == .Art || lootType == .Coke {
                 XCTAssertEqual(optimalLoot[lootType]!, 1, accuracy: ACCURACY)
+            } else {
+                XCTAssertEqual(optimalLoot[lootType]!, 0, accuracy: ACCURACY)
+            }
+        }
+        
+        capacity = 1
+        lootCounts = [
+            SecondaryLootTypes.Gold: 2,
+            SecondaryLootTypes.Art: 4,
+            SecondaryLootTypes.Cash: 0,
+            SecondaryLootTypes.Coke: 2,
+            SecondaryLootTypes.Weed: 0
+        ]
+        
+        optimalLoot = OptimalLootUtils.getOptimalLoot(capacity: capacity, lootCounts: lootCounts)
+        for lootType in SecondaryLootTypes.allCases {
+            if lootType == .Gold {
+                XCTAssertEqual(optimalLoot[lootType]!, 1.5, accuracy: ACCURACY)
             } else {
                 XCTAssertEqual(optimalLoot[lootType]!, 0, accuracy: ACCURACY)
             }

--- a/Optimal-Cayo-Perico-TakeUITests/Optimal_Cayo_Perico_TakeUITests.swift
+++ b/Optimal-Cayo-Perico-TakeUITests/Optimal_Cayo_Perico_TakeUITests.swift
@@ -18,18 +18,23 @@ class Optimal_Cayo_Perico_TakeUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        // Calculate button should not appear when the app starts
         let tablesQuery = XCUIApplication().tables
         XCTAssertFalse(app.toolbars["Toolbar"].exists)
         
         for stepperType in StepperTypes.allCases {
+            // trying to increment each stepper by 1
             let originalQuantity = stepperType == StepperTypes.Players ? 1 : 0
             let idString = "\(stepperType.rawValue): \(originalQuantity)"
             
             tablesQuery.cells.containing(.staticText, identifier: idString).buttons["Increment"].tap()
             XCTAssert(tablesQuery.cells.containing(.staticText, identifier: idString).count == 0)
+            
+            // if any loot type is > 1, the calculate button should appear
             XCTAssert(app.toolbars["Toolbar"].exists)
         }
         
+        // calculate button should still appear, as the loot types have been incremented
         XCTAssert(app.toolbars["Toolbar"].exists)
         app.toolbars["Toolbar"].buttons["Calculate Optimal Loot"].tap()
         app.navigationBars["Optimal_Cayo_Perico_Take.CalculationView"].buttons["Back"].tap()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Optimal-Cayo-Perico-Take
-iOS app that uses a modified version of the Fractional Knapsack algorithm to compute the secondary loot to take that yields the maximum profit in the Cayo Perico heist from GTA Online.
+iOS app that uses the Fractional Knapsack algorithm to compute the secondary loot to take that yields the maximum profit in the Cayo Perico heist from GTA Online.
 
 [![Build Status](https://travis-ci.com/dpaez16/Optimal-Cayo-Perico-Take.svg?branch=main)](https://travis-ci.com/dpaez16/Optimal-Cayo-Perico-Take)
 [![codecov](https://codecov.io/gh/dpaez16/Optimal-Cayo-Perico-Take/branch/main/graph/badge.svg?token=5AS7SSK93W)](https://codecov.io/gh/dpaez16/Optimal-Cayo-Perico-Take)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
       ignore: IGNORE,
       cobertura_xml: true,
       output_directory: OUTPUT_DIR,
-      travis: true
+      travis: is_ci
     )
   end
 


### PR DESCRIPTION
- Reverted `fractionalKnapsack` back to textbook function.
- Created `getOptimalLootHelper` to fix tricky edge cases with Artwork being a binary loot type.
- Simplified `SecondaryLootType` enum interface.
- Added additional unit tests for more thorough testing. 
- Minor fastlane config change.
- Updated README.