### PR TITLE
Changing upper bound for inputting loot item count

### DIFF
--- a/Optimal-Cayo-Perico-Take/Constants.swift
+++ b/Optimal-Cayo-Perico-Take/Constants.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+let MIN_PLAYERS: Double = 1
+let MAX_PLAYERS: Double = 4
+let MIN_LOOT_COUNT: Double = 0
+let MAX_LOOT_COUNT: Double = 15
+
 public enum SecondaryLootTypes: String, CaseIterable {
     case Gold
     case Art

--- a/Optimal-Cayo-Perico-Take/UserInputTableViewCell.swift
+++ b/Optimal-Cayo-Perico-Take/UserInputTableViewCell.swift
@@ -20,8 +20,8 @@ class UserInputTableViewCell: UITableViewCell {
         self.navigationController = navigationController
         stepper.isContinuous = false
         stepper.stepValue = 1
-        stepper.minimumValue = stepperType == StepperTypes.Players ? 1 : 0
-        stepper.maximumValue = stepperType == StepperTypes.Players ? 4 : 10
+        stepper.minimumValue = stepperType == StepperTypes.Players ? MIN_PLAYERS : MIN_LOOT_COUNT
+        stepper.maximumValue = stepperType == StepperTypes.Players ? MAX_PLAYERS : MAX_LOOT_COUNT
         stepper.value = getStepperQuantityAlt()
         userInputLabel.text = getProperLabelStr()
     }


### PR DESCRIPTION
- Upper bound for loot item count in the input screen is set to 15
- Added constants for better maintainability